### PR TITLE
Fixed DESCRIPTION error and changed required R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,7 @@ Package: snakesandladders
 Title: Snakes and Ladders Probability Simulator
 Version: 0.0.0.9000
 Authors@R: person("Ian", "Windham", email = "iwindham@vols.utk.edu", role = c("aut", "cre"))
-Description: This package computes the probability of being on each board square after n moves, as well as the probability the game will finish after
-n moves, for any given set of game parameters.  
+Description: This package computes the probability of being on each board square after n moves, as well as the probability the game will finish after n moves, for any given set of game parameters.  
 Depends: R (>= 3.4.0)
 License: CC0
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Snakes and Ladders Probability Simulator
 Version: 0.0.0.9000
 Authors@R: person("Ian", "Windham", email = "iwindham@vols.utk.edu", role = c("aut", "cre"))
 Description: This package computes the probability of being on each board square after n moves, as well as the probability the game will finish after n moves, for any given set of game parameters.  
-Depends: R (>= 3.4.0)
+Depends: R (>= 3.3.0)
 License: CC0
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
There was an extraneous line break in the Description field, which I removed. I also set the required R version to 3.3.0, since that's what I'm running. Probably makes sense to set it to 3.0.0.

n.b. I can't load the vignette for some reason. I spent some time trying to figure out why - you appear to have set it up correctly, and I'm installing using `devtools::instal_github("adsteen/snakesandladders", build_vignettes = TRUE)`. However, I can read the vignette since you put the .md file on github.

This is really great work.